### PR TITLE
Set RHOME env-var to account for Rscript

### DIFF
--- a/R-Portable-Mac/bin/R
+++ b/R-Portable-Mac/bin/R
@@ -58,6 +58,8 @@ export R_INCLUDE_DIR
 #R_DOC_DIR=/Library/Frameworks/R.framework/Resources/doc
 R_DOC_DIR=${R_HOME_DIR}/doc
 export R_DOC_DIR
+RHOME="${R_HOME_DIR}"
+export RHOME
 
 # Since this script can be called recursively, we allow R_ARCH to
 # be overridden from the environment.


### PR DESCRIPTION
Rscript is not portable because it uses a compile time absolute path for the R home directory. So any R code that calls something like `system('/path/to/Rscript', ...)` will fail because the Rscript file will in turn call R at the original hard-coded absolute path. For example, parallel::newPSOCKnode() uses this type of command, meaning that any code using PSOCK parallel cluster will not work.

I am not sure if shiny or any of this electron setup ever calls code that in turn makes a call to Rscript. If not, then it is probably fine.

Interestingly, Rscript does check to see if the R home directory is being overridden in the environment, and uses that path instead of the compile time path. However, it does so by looking for the deprecated RHOME env-var instead of R_HOME. Instead of re-compiling Rscript (and wrangling with all the tooling involved in that), we can work around it by assigning into the RHOME env-var as well.

I actually have not tested your library here, but I was reading through it because I was trying to create a portable R as well. I see that you have a binary Rscript in the root directory, so maybe this is a re-compiled version that works so maybe my change is not needed at all. 

You can test it simply by `./R-Portable-Mac/bin/Rscript -e "R.home()"` and see if that is correctly set. Without this current fix, my attempt at portable R was giving me the compile time path rather than the ported path.